### PR TITLE
Refactor related image vocabulary to support multilingual content sources

### DIFF
--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,0 +1,1 @@
+Replace module-level vocabulary try/except with a ComponentLookupError-based factory that delegates to `RootCatalog` (multilingual) or `Catalog` (fallback) for the related image source. Register as `cs_dynamicpages.RelatedImageSource` vocabulary.

--- a/src/cs_dynamicpages/behaviors/configure.zcml
+++ b/src/cs_dynamicpages/behaviors/configure.zcml
@@ -60,6 +60,11 @@
       />
 
 
+  <utility
+      name="cs_dynamicpages.RelatedImageSource"
+      component=".related_image.RelatedImageSourceVocabularyFactory"
+      />
+
   <plone:behavior
       name="cs_dynamicpages.related_image"
       title="RelatedImage"

--- a/src/cs_dynamicpages/behaviors/related_image.py
+++ b/src/cs_dynamicpages/behaviors/related_image.py
@@ -13,9 +13,12 @@ from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import adapter
+from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import provider
+from zope.interface.interfaces import ComponentLookupError
+from zope.schema.interfaces import IVocabularyFactory
 
 
 try:
@@ -28,6 +31,25 @@ except ImportError:
     from plone.app.z3cform.widgets.relateditems import (
         RelatedItemsFieldWidget as RelatedImageFieldWidget,
     )
+
+
+@implementer(IVocabularyFactory)
+class RelatedImageSourceVocabularyFactory:
+    """Vocabulary that delegates to RootCatalog if available, else Catalog."""
+
+    def __call__(self, context):
+        try:
+            factory = getUtility(
+                IVocabularyFactory, "plone.app.multilingual.RootCatalog"
+            )
+            return factory(context)
+        except ComponentLookupError:
+            return getUtility(IVocabularyFactory, "plone.app.vocabularies.Catalog")(
+                context
+            )
+
+
+RelatedImageSourceVocabularyFactory = RelatedImageSourceVocabularyFactory()
 
 
 class IImageRelationList(Interface):
@@ -52,14 +74,14 @@ class IRelatedImage(model.Schema):
         description=_("Select the related image that will be shown in this row"),
         default=[],
         max_length=1,
-        value_type=RelationChoice(vocabulary="plone.app.vocabularies.Catalog"),
+        value_type=RelationChoice(vocabulary="cs_dynamicpages.RelatedImageSource"),
         required=False,
     )
 
     form.widget(
         "related_image",
         RelatedImageFieldWidget,
-        vocabulary="plone.app.vocabularies.Catalog",
+        vocabulary="cs_dynamicpages.RelatedImageSource",
     )
     image_position = schema.Choice(
         title=_("Image position"),

--- a/src/cs_dynamicpages/tests/test_behavior_related_image.py
+++ b/src/cs_dynamicpages/tests/test_behavior_related_image.py
@@ -1,5 +1,9 @@
+from cs_dynamicpages.behaviors.related_image import IImageRelationList
+from cs_dynamicpages.behaviors.related_image import ImageRelationList
+from cs_dynamicpages.behaviors.related_image import IRelatedImage
 from cs_dynamicpages.behaviors.related_image import IRelatedImageMarker
 from cs_dynamicpages.testing import CS_DYNAMICPAGES_INTEGRATION_TESTING
+from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.behavior.interfaces import IBehavior
@@ -16,9 +20,49 @@ class RelatedImageIntegrationTest(unittest.TestCase):
         self.portal = self.layer["portal"]
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
 
-    def test_behavior_related_image(self):
+    def test_behavior_related_image_registered(self):
         behavior = getUtility(IBehavior, "cs_dynamicpages.related_image")
         self.assertEqual(
             behavior.marker,
             IRelatedImageMarker,
         )
+
+    def test_related_image_field_vocabulary_name(self):
+        field = IRelatedImage["related_image"]
+        self.assertEqual(
+            field.value_type.vocabularyName,
+            "cs_dynamicpages.RelatedImageSource",
+        )
+
+    def test_related_image_field_max_length(self):
+        field = IRelatedImage["related_image"]
+        self.assertEqual(field.max_length, 1)
+
+    def test_image_position_field_config(self):
+        field = IRelatedImage["image_position"]
+        self.assertEqual(field.vocabularyName, "cs_dynamicpages.ImagePosition")
+        self.assertEqual(field.default, "left")
+        self.assertTrue(field.required)
+
+    def test_image_relation_list_marker(self):
+        self.assertTrue(IImageRelationList.providedBy(ImageRelationList()))
+
+    def test_related_image_adapter_getter_setter(self):
+        self.portal.invokeFactory("Document", "doc1", title="Doc 1")
+        doc = self.portal["doc1"]
+
+        fti = api.portal.get_tool("portal_types").getTypeInfo("Document")
+        behaviors = list(fti.behaviors)
+        behaviors.append("cs_dynamicpages.related_image")
+        fti.behaviors = tuple(behaviors)
+
+        behavior = getUtility(IBehavior, "cs_dynamicpages.related_image")
+        adapter = behavior.factory(doc)
+
+        adapter.image_position = "right"
+        self.assertEqual(adapter.image_position, "right")
+        self.assertEqual(doc.image_position, "right")
+
+        adapter.related_image = []
+        self.assertEqual(adapter.related_image, [])
+        self.assertEqual(doc.related_image, [])


### PR DESCRIPTION
- Replace module-level try/except VOCAB constant with a ComponentLookupError-based vocabulary factory that delegates to RootCatalog (multilingual) or Catalog (fallback)
- Register vocabulary as cs_dynamicpages.RelatedImageSource in configure.zcml
- Extend integration tests for behavior registration, field config, adapter, and vocabulary name


Fixes #39 